### PR TITLE
General docs fixes

### DIFF
--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -6,4 +6,4 @@ About the Noroff API
 
 The current version of this API is **v1**.
 
-The API base URL for v1 is `https://example.com/api/v1`.
+The API base URL for v1 is `https://nf-api.onrender.com/api/v1`.

--- a/pages/basic-endpoints/authentication.mdx
+++ b/pages/basic-endpoints/authentication.mdx
@@ -39,7 +39,6 @@ You can now use this access token as the Bearer token in the `Authorization` hea
 ```js
 const options = {
   headers: {
-    'Content-Type': 'application/json',
     Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9....',
   },
 }

--- a/pages/social-endpoints/authentication.mdx
+++ b/pages/social-endpoints/authentication.mdx
@@ -19,7 +19,7 @@ This endpoint will register a new user profile. You will need to send all of the
 ```json
 {
   "name": "my_username", // Required
-  "email": "first.last@noroff.no", // Required
+  "email": "first.last@stud.noroff.no", // Required
   "password": "UzI1NiIsInR5cCI", // Required
   "avatar": "https://img.service.com/avatar.jpg", // Optional
   "banner": "https://img.service.com/banner.jpg" // Optional
@@ -28,7 +28,7 @@ This endpoint will register a new user profile. You will need to send all of the
 
 > The `name` value must not contain punctuation symbols apart from underscore (`_`).
 
-> The `email` value must be a valid `noroff.no` email address.
+> The `email` value must be a valid `stud.noroff.no` or `noroff.no` email address.
 
 > The `password` value must be at least 8 characters.
 

--- a/pages/social-endpoints/authentication.mdx
+++ b/pages/social-endpoints/authentication.mdx
@@ -18,11 +18,11 @@ This endpoint will register a new user profile. You will need to send all of the
 
 ```json
 {
-  "name": "my_username", // Required
-  "email": "first.last@stud.noroff.no", // Required
-  "password": "UzI1NiIsInR5cCI", // Required
+  "name": "my_username",                          // Required
+  "email": "first.last@stud.noroff.no",           // Required
+  "password": "UzI1NiIsInR5cCI",                  // Required
   "avatar": "https://img.service.com/avatar.jpg", // Optional
-  "banner": "https://img.service.com/banner.jpg" // Optional
+  "banner": "https://img.service.com/banner.jpg"  // Optional
 }
 ```
 

--- a/pages/social-endpoints/posts.mdx
+++ b/pages/social-endpoints/posts.mdx
@@ -106,6 +106,8 @@ Lists can be sorted by any item properties, in the order ascending (`asc`) or de
 
 ## Single entry
 
+#### GET /api/v1/social/posts/\<id>
+
 This endpoint returns a single registered endpoint.
 
 ```json
@@ -126,14 +128,16 @@ This endpoint returns a single registered endpoint.
 
 ## Create entry
 
+#### POST /api/v1/social/posts
+
 This endpoint allows for the creation of a new post. The `title` property is required. The request body contains:
 
 ```json
 {
-  "title": "string",   // Required
-  "body": "string",    // Required
-  "tags": ["string"],  // Optional
-  "media": "string"    // Optional
+  "title": "string",  // Required
+  "body": "string",   // Required
+  "tags": ["string"], // Optional
+  "media": "string"   // Optional
 }
 ```
 
@@ -154,6 +158,8 @@ The response body contains:
 ```
 
 ## Update entry
+
+#### PUT /api/v1/social/posts/\<id>
 
 This endpoint updates an entry based on its id and returns the updated entry.
 
@@ -186,13 +192,13 @@ The response body contains:
 
 ## Delete entry
 
+#### DELETE /api/v1/social/posts/\<id>
+
 This endpoint deletes an entry based on its id and returns nothing.
 
-```json
-// DELETE /api/v1/social/posts/\<id>
-```
-
 ## React to entry
+
+#### PUT /api/v1/social/posts/\<id>/react/\<symbol>
 
 React to an entry with a symbol. Returns the reaction count for that symbol, the post, and the post id.
 
@@ -208,6 +214,8 @@ React to an entry with a symbol. Returns the reaction count for that symbol, the
 ```
 
 ## Comment on entry
+
+#### POST /api/v1/social/posts/\<id>/comment
 
 This endpoint allows a comment to be made on a post. The optional `replyToId` property can be used to link this comment to an existing comment.
 

--- a/pages/social-endpoints/posts.mdx
+++ b/pages/social-endpoints/posts.mdx
@@ -131,7 +131,7 @@ This endpoint allows for the creation of a new post. The `title` property is req
 ```json
 {
   "title": "string",   // Required
-  "body": "string",    // Optional
+  "body": "string",    // Required
   "tags": ["string"],  // Optional
   "media": "string"    // Optional
 }

--- a/theme.config.js
+++ b/theme.config.js
@@ -1,6 +1,6 @@
 export default {
-  github: 'https://github.com/jaaneh/noroff-api-docs',
-  docsRepositoryBase: 'https://github.com/jaaneh/noroff-api-docs/tree/main',
+  github: 'https://github.com/NoroffFEU/noroff-api-docs',
+  docsRepositoryBase: 'https://github.com/NoroffFEU/noroff-api-docs',
   titleSuffix: ' – Noroff API Documentation',
   logo: (
     <>


### PR DESCRIPTION
- Changes all `noroff.no` to `stud.noroff.no` in examples for consistency.
- Mark the `body` property of creating a new Post as required. This is inline with the API functionality.
- Removes `Content-Type` in the example code block of how to send an Authorization header. This was already removed on Social endpoints Auth page but was still present on Basic endpoints auth page.
- Changes `example.com` to `nf-api.onrender.com` on the About page.
- Changes repo URL in header and footer. This was previously linking to my account instead of NoroffFEU.
- Adds the headings showing method and path (i.e. `GET /api/v1/`) to the routes that were missing those.