### PR TITLE
holidaze: Add missing venue location

### DIFF
--- a/pages/holidaze/bookings.mdx
+++ b/pages/holidaze/bookings.mdx
@@ -67,6 +67,15 @@ Not all of the properties of a booking are returned by default. You can use the 
       "parking": true,
       "breakfast": true,
       "pets": true
+    },
+    "location": {
+      "address": "string",
+      "city": "string",
+      "zip": "string",
+      "country": "string",
+      "continent": "string",
+      "lat": 0,
+      "lng": 0
     }
   },
   "customer": {

--- a/pages/holidaze/profiles.mdx
+++ b/pages/holidaze/profiles.mdx
@@ -73,6 +73,15 @@ Not all of the properties of a profile are returned by default. You can use the 
         "parking": true,
         "breakfast": true,
         "pets": true
+      },
+      "location": {
+        "address": "string",
+        "city": "string",
+        "zip": "string",
+        "country": "string",
+        "continent": "string",
+        "lat": 0,
+        "lng": 0
       }
     }
   ],
@@ -201,6 +210,15 @@ The response is the same as the [venues](./venues#all-entries) endpoint, and acc
       "parking": true,
       "breakfast": true,
       "pets": true
+    },
+    "location": {
+      "address": "string",
+      "city": "string",
+      "zip": "string",
+      "country": "string",
+      "continent": "string",
+      "lat": 0,
+      "lng": 0
     }
   },
   {
@@ -217,6 +235,15 @@ The response is the same as the [venues](./venues#all-entries) endpoint, and acc
       "parking": true,
       "breakfast": true,
       "pets": true
+    },
+    "location": {
+      "address": "string",
+      "city": "string",
+      "zip": "string",
+      "country": "string",
+      "continent": "string",
+      "lat": 0,
+      "lng": 0
     }
   }
   // ...


### PR DESCRIPTION
- Some venue models were missing the new `location` property.